### PR TITLE
Fixed vuex import path for vuex 2.1.1

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,7 +4,7 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 import Api from "src/api/index"
-import createLogger from 'vuex/logger'
+import createLogger from 'vuex/dist/logger'
 
 Vue.use(Vuex)
 


### PR DESCRIPTION
Hi,

When execute npm run dev, it shows error,

ERROR in ./src/store/index.js
Module not found: Error: Can't resolve 'vuex/logger' in '....\yelingfeng-vue2-FamilyBucket\src\store'

Found out it is the path issue for,
import createLogger from 'vuex/logger'

It should be,
import createLogger from 'vuex/dist/logger'

Thank you,
